### PR TITLE
Support TLS config for DB connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@
 
 [![Test](https://github.com/rubenv/sql-migrate/actions/workflows/test.yml/badge.svg)](https://github.com/rubenv/sql-migrate/actions/workflows/test.yml) [![Go Reference](https://pkg.go.dev/badge/github.com/rubenv/sql-migrate.svg)](https://pkg.go.dev/github.com/rubenv/sql-migrate)
 
+# **WORKAROUND EDITION**
+- This repository is a workaround implementation for sql-migrate to interact with AWS RDS TLS certificates pem tls connection. Not an official supported.
+- Configuration example:
+
+```yml
+production:
+  dialect: mysql
+  datasource: root@/dbname?parseTime=true&charset=utf8mb4&tls=custom
+  dir: migrations/mysql
+  table: migrations
+  tls:
+    ca: /path/ca-cert
+    cert: /path/client-cert
+    key: /path/client-key
+```
+
 ## Features
 
 - Usable as a CLI tool or as a library

--- a/sql-migrate/config.go
+++ b/sql-migrate/config.go
@@ -131,7 +131,7 @@ func GetConnection(env *Environment) (*sql.DB, string, error) {
 	// Make sure we only accept dialects that were compiled in.
 	_, exists := dialects[env.Dialect]
 	if !exists {
-		return nil, "", fmt.Errorf("unsupported dialect: %s", env.Dialect)
+		return nil, "", fmt.Errorf("Unsupported dialect: %s", env.Dialect)
 	}
 
 	return db, env.Dialect, nil

--- a/sql-migrate/config.go
+++ b/sql-migrate/config.go
@@ -125,7 +125,7 @@ func GetConnection(env *Environment) (*sql.DB, string, error) {
 
 	db, err := sql.Open(env.Dialect, env.DataSource)
 	if err != nil {
-		return nil, "", fmt.Errorf("cannot connect to database: %w", err)
+		return nil, "", fmt.Errorf("Cannot connect to database: %w", err)
 	}
 
 	// Make sure we only accept dialects that were compiled in.

--- a/sql-migrate/config.go
+++ b/sql-migrate/config.go
@@ -1,18 +1,22 @@
 package main
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"database/sql"
 	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"runtime/debug"
+	"strings"
 
 	"github.com/go-gorp/gorp/v3"
 	"gopkg.in/yaml.v2"
 
 	migrate "github.com/rubenv/sql-migrate"
 
+	"github.com/go-sql-driver/mysql"
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
@@ -35,12 +39,19 @@ func ConfigFlags(f *flag.FlagSet) {
 }
 
 type Environment struct {
-	Dialect       string `yaml:"dialect"`
-	DataSource    string `yaml:"datasource"`
-	Dir           string `yaml:"dir"`
-	TableName     string `yaml:"table"`
-	SchemaName    string `yaml:"schema"`
-	IgnoreUnknown bool   `yaml:"ignoreunknown"`
+	Dialect       string    `yaml:"dialect"`
+	DataSource    string    `yaml:"datasource"`
+	Dir           string    `yaml:"dir"`
+	TableName     string    `yaml:"table"`
+	SchemaName    string    `yaml:"schema"`
+	IgnoreUnknown bool      `yaml:"ignoreunknown"`
+	Tls           TLSConfig `yaml:"tls"`
+}
+
+type TLSConfig struct {
+	CA   string `yaml:"ca"`
+	Cert string `yaml:"cert"`
+	Key  string `yaml:"key"`
 }
 
 func ReadConfig() (map[string]*Environment, error) {
@@ -78,6 +89,10 @@ func GetEnvironment() (*Environment, error) {
 	}
 	env.DataSource = os.ExpandEnv(env.DataSource)
 
+	env.Tls.CA = os.ExpandEnv(env.Tls.CA)
+	env.Tls.Cert = os.ExpandEnv(env.Tls.Cert)
+	env.Tls.Key = os.ExpandEnv(env.Tls.Key)
+
 	if env.Dir == "" {
 		env.Dir = "migrations"
 	}
@@ -96,15 +111,27 @@ func GetEnvironment() (*Environment, error) {
 }
 
 func GetConnection(env *Environment) (*sql.DB, string, error) {
+	// Load CA cert for RDS Aurora MySQL if tls specified
+	if env.Dialect == "mysql" && isTlsCustomEnabled(env) {
+		if env.Tls.CA == "" {
+			return nil, "", errors.New("file CA is not set")
+		}
+
+		err := RegisterTlsConfig(env.Tls.CA, "custom")
+		if err != nil {
+			return nil, "", fmt.Errorf("cannot register TLS config: %w", err)
+		}
+	}
+
 	db, err := sql.Open(env.Dialect, env.DataSource)
 	if err != nil {
-		return nil, "", fmt.Errorf("Cannot connect to database: %w", err)
+		return nil, "", fmt.Errorf("cannot connect to database: %w", err)
 	}
 
 	// Make sure we only accept dialects that were compiled in.
 	_, exists := dialects[env.Dialect]
 	if !exists {
-		return nil, "", fmt.Errorf("Unsupported dialect: %s", env.Dialect)
+		return nil, "", fmt.Errorf("unsupported dialect: %s", env.Dialect)
 	}
 
 	return db, env.Dialect, nil
@@ -116,4 +143,26 @@ func GetVersion() string {
 		return buildInfo.Main.Version
 	}
 	return "dev"
+}
+
+func RegisterTlsConfig(pemPath, tlsType string) (err error) {
+	caCertPool := x509.NewCertPool()
+	pem, err := os.ReadFile(pemPath)
+	if err != nil {
+		return err
+	}
+
+	if ok := caCertPool.AppendCertsFromPEM(pem); !ok {
+		return fmt.Errorf("cannot append certs from PEM")
+	}
+
+	mysql.RegisterTLSConfig(tlsType, &tls.Config{
+		RootCAs: caCertPool,
+	})
+
+	return nil
+}
+
+func isTlsCustomEnabled(env *Environment) bool {
+	return strings.Contains(env.DataSource, "tls=custom")
 }

--- a/test-integration/dbconfig.yml
+++ b/test-integration/dbconfig.yml
@@ -18,6 +18,15 @@ mysql_env:
     datasource: ${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/${DATABASE_NAME}?parseTime=true
     dir: test-migrations
 
+mysql_ssl:
+    dialect: mysql
+    datasource: ${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/${DATABASE_NAME}?parseTime=true&tls=custom
+    dir: test-migrations
+    tls:
+        ca: ${MYSQL_CA_CERT_FILE}
+        cert: ${MYSQL_CLIENT_CERT_FILE}
+        key: ${MYSQL_CLIENT_KEY_FILE}
+
 sqlite:
     dialect: sqlite3
     datasource: test.db


### PR DESCRIPTION
- `sql-migrate` tools currently not support PEM & CA certs for RDS tls connection
- Support passing ca-files to open the Db connection when `tls=custom`